### PR TITLE
restage formatted files to make hook succeed first time

### DIFF
--- a/src/runic.jl
+++ b/src/runic.jl
@@ -1,6 +1,29 @@
 #!/usr/bin/env julia
 
 using Runic
+
+# Get the list of files passed to the hook
+files = ARGS
+
+# Run Runic with --inplace --diff
 argv = String["--inplace", "--diff"]
-append!(argv, ARGS)
-exit(Runic.main(argv))
+append!(argv, files)
+exit_code = Runic.main(argv)
+
+# If Runic succeeded, re-stage any files that were modified
+if exit_code == 0
+    for file in files
+        # Check if this file has unstaged changes (was modified by Runic)
+        # Use git diff --name-only to check if file has unstaged changes
+        result = readlines(`git diff --name-only -- $file`)
+        if !isempty(result) && file in result
+            # File was modified by Runic and has unstaged changes, re-stage it
+            # Since pre-commit only passes staged files to hooks, we know this file
+            # was originally staged and should be re-staged with the formatting changes
+            run(`git add $file`)
+        end
+    end
+end
+
+# Always exit with the same code Runic returned
+exit(exit_code)


### PR DESCRIPTION
On the Pkg repo if I have bad formatting, when I commit the hook will fail but actually fix the formatting, then the 2nd commit will succeed.

I think this fixes the issue, which is that we're not re-staging files after modifying them?

cc. @kristofferc