### PR TITLE
Fix Markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ repos:
 ### Markdown files
 
 To also format Julia code blocks in Markdown files, add the `runic-md` hook (requires Runic
->= 1.7):
+\>= 1.7):
 
 ```yaml
 repos:


### PR DESCRIPTION
The `>` at the beginning of the line makes the Markdown parser think that it's the beginning of a blockquote. I'd ordinarily prefer to just move it to the previous line (generally I like semantic line breaks :)) but I noticed the file is formatted with a maximum line width so escaping the character seemed to be the best way to preserve that while avoiding the incorrect rendering.